### PR TITLE
fix: resolve duplicate permalink conflict for categories build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -102,11 +102,21 @@ module.exports = function (eleventyConfig) {
    */
   eleventyConfig.addFilter("slugify", (str) => {
     if (!str) return "";
-    return String(str)
+
+    // Unicode 文字（日本語など）を保持しつつ、URL パスとして安全な形式に整える。
+    // 以前の実装は \w のみ許可していたため、日本語カテゴリが空文字になり
+    // /categories/index.html へ衝突していた。
+    const normalizedSlug = String(str)
+      .normalize("NFKC")
       .toLowerCase()
       .trim()
       .replace(/[\s]+/g, "-")
-      .replace(/[^\w-]/g, "");
+      .replace(/[^\p{L}\p{N}_-]/gu, "")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "");
+
+    // 記号のみなどで空になった場合は衝突回避のため固定値を返す。
+    return normalizedSlug || "untitled";
   });
 
   /**

--- a/.github/workflows/deploy-public.yml
+++ b/.github/workflows/deploy-public.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Test typography configuration
         run: npm run test:typography
 
+      # Run test:slugify (before build - prevents taxonomy permalink conflicts)
+      - name: Test slugify behavior
+        run: npm run test:slugify
+
       # Build the site
       - name: Build site
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:link-validation": "node scripts/validate-internal-links.js",
     "test:animations": "node scripts/validate-animations.js",
     "test:typography": "node scripts/validate-typography.js",
+    "test:slugify": "node scripts/validate-slugify.js",
     "test:lint": "eslint . --ext .js",
     "test:theme": "node scripts/validate-theme.js",
     "test:a11y": "node scripts/validate-a11y.js",

--- a/scripts/validate-slugify.js
+++ b/scripts/validate-slugify.js
@@ -1,0 +1,90 @@
+/**
+ * Slugify Validation Test
+ *
+ * Purpose: slugify フィルターが Unicode 文字（日本語など）を安全に処理し、
+ *          taxonomy ページの permalink 衝突を防げることを検証する
+ *
+ * Usage: npm run test:slugify
+ *
+ * Expected:
+ * - 日本語カテゴリでも空文字にならない
+ * - 記号のみ入力でもフォールバック値を返す
+ * - 同一入力は常に同一 slug を返す
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+function getSlugifyFilter() {
+  const configModule = require("../.eleventy.js");
+  const filters = {};
+
+  const eleventyConfigStub = {
+    addPassthroughCopy() {},
+    addGlobalData() {},
+    addNunjucksAsyncShortcode() {},
+    addCollection() {},
+    addFilter(name, filterFunction) {
+      filters[name] = filterFunction;
+    },
+  };
+
+  configModule(eleventyConfigStub);
+
+  if (typeof filters.slugify !== "function") {
+    throw new Error("slugify filter is not registered");
+  }
+
+  return filters.slugify;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function main() {
+  const slugify = getSlugifyFilter();
+
+  const englishSlug = slugify("General Category");
+  assert(englishSlug === "general-category", "English slug normalization failed");
+
+  const japaneseSlug = slugify("デザイン");
+  assert(japaneseSlug.length > 0, "Japanese slug must not be empty");
+
+  const symbolOnlySlug = slugify("###");
+  assert(symbolOnlySlug === "untitled", "Symbol-only input must fallback to untitled");
+
+  const deterministicA = slugify("デザイン");
+  const deterministicB = slugify("デザイン");
+  assert(deterministicA === deterministicB, "Slugify must be deterministic");
+
+  const articlePath = path.join(__dirname, "../content/articles");
+  const articleFiles = fs.readdirSync(articlePath).filter((fileName) => fileName.endsWith(".md"));
+
+  const categories = [];
+  for (const articleFile of articleFiles) {
+    const articleContent = fs.readFileSync(path.join(articlePath, articleFile), "utf-8");
+    const categoryMatch = articleContent.match(/^category:\s*(.+)$/m);
+
+    if (categoryMatch && categoryMatch[1]) {
+      categories.push(categoryMatch[1].trim());
+    }
+  }
+
+  for (const categoryName of categories) {
+    const categorySlug = slugify(categoryName);
+    assert(categorySlug.length > 0, `Category slug must not be empty: ${categoryName}`);
+  }
+
+  console.log("✅ slugify validation passed");
+}
+
+try {
+  main();
+} catch (error) {
+  console.error("❌ slugify validation failed");
+  console.error(error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Fixes Eleventy build failure caused by duplicate output to `_site/categories/index.html`
- Updates `slugify` filter to support Unicode category/tag names safely
- Adds regression test for slugify behavior
- Integrates slugify validation into CI before build

## Root Cause
`slugify` removed non-ASCII characters via `[^\\w-]`, so Japanese category names (e.g. `デザイン`) became an empty slug. This caused `content/categories.njk` to generate `/categories/index.html`, conflicting with `content/categories/index.md`.

## Changes
- **`.eleventy.js`**
  - Made `slugify` Unicode-aware using `\p{L}` and `\p{N}`
  - Added normalization/cleanup and fallback (`untitled`) for empty results
- **`scripts/validate-slugify.js`**
  - New validation script with Purpose/Usage/Expected header
  - Covers Japanese input, symbol-only fallback, determinism, and real article categories
- **`package.json`**
  - Added `npm run test:slugify`
- **`.github/workflows/deploy-public.yml`**
  - Added `Test slugify behavior` step before build

## Validation
- `npm run test:slugify` ✅
- `npm run build` ✅

## Impact
- Prevents taxonomy permalink collisions in multilingual content
- Keeps CI aligned to catch regressions before deploy