### PR TITLE
fix: 本番記事ページのCSS未適用を修正し再発防止テストを追加 (#36)

### DIFF
--- a/.github/workflows/deploy-public.yml
+++ b/.github/workflows/deploy-public.yml
@@ -72,6 +72,10 @@ jobs:
       - name: Test visual effects (shadows, backgrounds)
         run: npm run test:visual-effects
 
+      # Run test:article-css
+      - name: Test article CSS loading
+        run: npm run test:article-css
+
       # Deploy to GitHub Pages (on master push only)
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/content/_includes/layouts/article.njk
+++ b/content/_includes/layouts/article.njk
@@ -1,3 +1,7 @@
+---
+layout: layouts/base
+---
+
 {#
   article.njk: 記事ページの専用レイアウト
   
@@ -16,9 +20,6 @@
     
     記事本文 (Markdown)
 #}
----
-layout: base
----
 
 {%- set site = site | default({}) -%}
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:a11y": "node scripts/validate-a11y.js",
     "test:visual-effects": "node scripts/validate-visual-effects.js",
     "test:e2e": "playwright test",
-    "test:article-design": "node scripts/validate-article-design.js"
+    "test:article-design": "node scripts/validate-article-design.js",
+    "test:article-css": "node scripts/validate-article-css.js"
   },
   "devDependencies": {
     "@11ty/eleventy": "^2.0.0",

--- a/scripts/validate-article-css.js
+++ b/scripts/validate-article-css.js
@@ -33,6 +33,13 @@ let passed = 0;
 let failed = 0;
 
 /**
+ * 正規表現メタ文字をエスケープする
+ */
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * 記事ディレクトリ配下の index.html 一覧を再帰的に取得する
  */
 function getArticleHtmlFiles(directoryPath) {
@@ -66,12 +73,24 @@ function validateArticlePage(filePath) {
   const html = fs.readFileSync(filePath, "utf-8");
   const relativePath = path.relative(SITE_DIR, filePath);
 
-  const hasStylesheetLink = new RegExp(
-    `<link\\s+rel=["']stylesheet["']\\s+href=["']${REQUIRED_STYLESHEET_HREF}["']`,
+  const linkTagRegex = /<link\b[^>]*>/gi;
+  const relStylesheetRegex = /\brel=["']stylesheet["']/i;
+  const hrefRegex = new RegExp(
+    `\\bhref=["']${escapeRegExp(REQUIRED_STYLESHEET_HREF)}["']`,
     "i"
-  ).test(html);
+  );
 
-  const hasFrontMatterArtifact = /^\s*---\s*\r?\n\s*layout:\s*base\s*\r?\n\s*---/i.test(html);
+  let hasStylesheetLink = false;
+  let linkMatch;
+  while ((linkMatch = linkTagRegex.exec(html)) !== null) {
+    const linkTag = linkMatch[0];
+    if (relStylesheetRegex.test(linkTag) && hrefRegex.test(linkTag)) {
+      hasStylesheetLink = true;
+      break;
+    }
+  }
+
+  const hasFrontMatterArtifact = /(?:^|\r?\n)\s*---\s*\r?\n\s*layout:\s*(?:base|layouts\/base)\s*\r?\n\s*---/i.test(html);
 
   if (!hasStylesheetLink) {
     failed++;

--- a/scripts/validate-article-css.js
+++ b/scripts/validate-article-css.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+/**
+ * Test: validate-article-css.js
+ *
+ * Purpose: 記事ページで base レイアウトが適用され、CSS が正しく読み込まれることを検証する
+ *
+ * This test runs after `npm run build` and checks:
+ * 1. _site/articles 配下の各記事 index.html が生成されている
+ * 2. 各記事ページに <link rel="stylesheet" href="/my-main-blog/css/site.css"> が含まれる
+ * 3. Front Matter の生文字列（--- / layout: base）が本文に混入していない
+ *
+ * Usage: npm run test:article-css
+ * Expected: ✅ Pass (all article pages load CSS via base layout)
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const SITE_DIR = path.join(process.cwd(), "_site");
+const ARTICLES_DIR = path.join(SITE_DIR, "articles");
+const REQUIRED_STYLESHEET_HREF = "/my-main-blog/css/site.css";
+
+const colors = {
+  reset: "\x1b[0m",
+  green: "\x1b[32m",
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[36m",
+};
+
+let passed = 0;
+let failed = 0;
+
+/**
+ * 記事ディレクトリ配下の index.html 一覧を再帰的に取得する
+ */
+function getArticleHtmlFiles(directoryPath) {
+  const htmlFiles = [];
+
+  function walk(currentDirectory) {
+    const entries = fs.readdirSync(currentDirectory, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const entryPath = path.join(currentDirectory, entry.name);
+
+      if (entry.isDirectory()) {
+        walk(entryPath);
+        continue;
+      }
+
+      if (entry.isFile() && entry.name === "index.html") {
+        htmlFiles.push(entryPath);
+      }
+    }
+  }
+
+  walk(directoryPath);
+  return htmlFiles;
+}
+
+/**
+ * 単一記事ページの検証を行う
+ */
+function validateArticlePage(filePath) {
+  const html = fs.readFileSync(filePath, "utf-8");
+  const relativePath = path.relative(SITE_DIR, filePath);
+
+  const hasStylesheetLink = new RegExp(
+    `<link\\s+rel=["']stylesheet["']\\s+href=["']${REQUIRED_STYLESHEET_HREF}["']`,
+    "i"
+  ).test(html);
+
+  const hasFrontMatterArtifact = /^\s*---\s*\r?\n\s*layout:\s*base\s*\r?\n\s*---/i.test(html);
+
+  if (!hasStylesheetLink) {
+    failed++;
+    console.log(
+      `${colors.red}✘${colors.reset} ${relativePath} : stylesheet link missing (${REQUIRED_STYLESHEET_HREF})`
+    );
+  } else {
+    passed++;
+    console.log(`${colors.green}✓${colors.reset} ${relativePath} : stylesheet link found`);
+  }
+
+  if (hasFrontMatterArtifact) {
+    failed++;
+    console.log(`${colors.red}✘${colors.reset} ${relativePath} : front matter artifact detected`);
+  } else {
+    passed++;
+    console.log(`${colors.green}✓${colors.reset} ${relativePath} : no front matter artifact`);
+  }
+}
+
+function main() {
+  console.log(`\n${colors.blue}🔍 Article CSS Loading Validation${colors.reset}\n`);
+
+  // _site が未生成なら、ビルド漏れとして即失敗
+  if (!fs.existsSync(SITE_DIR)) {
+    console.error(`${colors.red}❌ Error: _site directory not found${colors.reset}`);
+    process.exit(1);
+  }
+
+  // 記事ディレクトリがなければ、記事生成の失敗として扱う
+  if (!fs.existsSync(ARTICLES_DIR)) {
+    console.error(`${colors.red}❌ Error: _site/articles directory not found${colors.reset}`);
+    process.exit(1);
+  }
+
+  const articleFiles = getArticleHtmlFiles(ARTICLES_DIR);
+
+  if (articleFiles.length === 0) {
+    console.error(`${colors.red}❌ Error: No article index.html files found${colors.reset}`);
+    process.exit(1);
+  }
+
+  console.log(`Found ${articleFiles.length} article page(s)\n`);
+
+  for (const filePath of articleFiles) {
+    validateArticlePage(filePath);
+  }
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`${colors.green}Passed${colors.reset}: ${passed}`);
+  console.log(`${colors.red}Failed${colors.reset}: ${failed}`);
+
+  if (failed > 0) {
+    console.log(`\n${colors.red}❌ Article CSS loading validation failed!${colors.reset}\n`);
+    process.exit(1);
+  }
+
+  console.log(`\n${colors.green}✅ All article pages correctly load CSS!${colors.reset}\n`);
+}
+
+main();


### PR DESCRIPTION
## 概要
本番の2つの記事ページでCSSが適用されない問題を修正し、同種の不具合をCIで検知できるようにしました。

## 変更内容
- `content/_includes/layouts/article.njk` の Front Matter をファイル先頭へ移動し、記事ページで `layouts/base` が確実に適用されるよう修正
- 記事ページのCSS読込とFront Matter混入を検証する `scripts/validate-article-css.js` を新規追加
- `package.json` に `test:article-css` を追加
- `.github/workflows/deploy-public.yml` に `npm run test:article-css` を追加（デプロイ前実行）

## 変更の種類
- [ ] 新機能追加
- [x] バグ修正
- [ ] ドキュメント更新
- [ ] リファクタリング
- [x] テスト追加・修正
- [x] CI/CD設定変更
- [ ] その他（具体的に: ）

## 関連Issue
Closes #36

## テスト
- [x] ローカルでビルドが成功することを確認
- [ ] 既存のテストが全てパスすることを確認
- [x] 新しいテストを追加（必要な場合）
- [ ] ブラウザで動作確認

実行コマンド:
- `npm run build`
- `npm run test:article-css`

## スクリーンショット
なし

## チェックリスト
- [x] コードが既存のスタイルガイドに従っている
- [x] 自己レビューを実施した
- [x] コメントは理解しやすい内容になっている
- [ ] ドキュメントを更新した（必要な場合）
- [x] 変更によって新しい警告が発生していない
- [ ] 依存関係の変更がある場合、package.jsonを更新した

## 補足事項
- 原因は `article.njk` の Front Matter がコメントブロック後ろにあり、Eleventyがレイアウト指定として解釈していなかった点です。
- 今後同様の崩れは `test:article-css` でデプロイ前に検知できます。